### PR TITLE
✨Feat: Add 사용자 설정 관련 API 추가

### DIFF
--- a/src/main/java/com/musai/musai/controller/difficulty/DifficultyController.java
+++ b/src/main/java/com/musai/musai/controller/difficulty/DifficultyController.java
@@ -1,0 +1,31 @@
+package com.musai.musai.controller.difficulty;
+
+import com.musai.musai.dto.difficulty.DifficultyRequestDTO;
+import com.musai.musai.dto.difficulty.DifficultyResponseDTO;
+import com.musai.musai.entity.user.DefaultDifficulty;
+import com.musai.musai.service.difficulty.DifficultyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/difficulty")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
+public class DifficultyController {
+
+    private final DifficultyService difficultyService;
+
+    @Operation (summary = "난이도별 해설 난이도 변경 (개발중)", description = "난이도별 해설 난이도 변경 API 개발 중입니다.")
+    @PostMapping("/{level}")
+    public ResponseEntity<?> convertDifficulty(
+            @PathVariable DefaultDifficulty level,
+            @RequestBody DifficultyRequestDTO request) {
+        String convertedText = difficultyService.convert(level, request.getOriginal());
+        return ResponseEntity.ok(new DifficultyResponseDTO(convertedText));
+    }
+
+}

--- a/src/main/java/com/musai/musai/controller/user/UserController.java
+++ b/src/main/java/com/musai/musai/controller/user/UserController.java
@@ -1,13 +1,12 @@
 package com.musai.musai.controller.user;
 
-import com.musai.musai.dto.RecogErrorDTO;
-import com.musai.musai.dto.RecogResponseDTO;
+import com.musai.musai.dto.user.SettingDTO;
 import com.musai.musai.dto.user.UserDTO;
 import com.musai.musai.dto.user.UserErrorDTO;
+import com.musai.musai.entity.user.DefaultDifficulty;
 import com.musai.musai.service.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -24,7 +23,6 @@ public class UserController {
 
     private final UserService userService;
 
-    //회원 정보 조회 api
     @Operation(summary = "회원 정보 조회", description = "회원 정보를 조회합니다.",
     responses = {
         @ApiResponse(
@@ -50,7 +48,6 @@ public class UserController {
         return ResponseEntity.ok(user);
     }
 
-    //회원 정보 수정 api
     @Operation(summary = "회원 정보 수정", description = "회원 정보(닉네임, 프로필 사진)를 수정합니다.",
             responses = {
                     @ApiResponse(
@@ -76,5 +73,22 @@ public class UserController {
             @RequestBody UserDTO userDTO) {
         UserDTO updateUser = userService.updateUser(userId, userDTO);
         return ResponseEntity.ok(updateUser);
+    }
+
+    @Operation(summary = "사용자 설정 조회", description = "사용자 설정 정보를 조회합니다..")
+    @GetMapping("/{userId}/difficulty")
+    public ResponseEntity<SettingDTO> readSetting (
+            @PathVariable Long userId) {
+        SettingDTO setting = userService.getSettingById(userId);
+        return ResponseEntity.ok(setting);
+    }
+
+    @Operation(summary = "난이도별 해설 기본값 수정", description = "난이도별 해설 기본값을 수정합니다.")
+    @PutMapping("/{userId}/difficulty/{level}")
+    public ResponseEntity<SettingDTO> updateLevel (
+            @PathVariable Long userId,
+            @PathVariable DefaultDifficulty level) {
+        SettingDTO updateSet = userService.updateLevel(userId, level);
+        return ResponseEntity.ok(updateSet);
     }
 }

--- a/src/main/java/com/musai/musai/dto/difficulty/DifficultyRequestDTO.java
+++ b/src/main/java/com/musai/musai/dto/difficulty/DifficultyRequestDTO.java
@@ -1,0 +1,10 @@
+package com.musai.musai.dto.difficulty;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DifficultyRequestDTO {
+    private String original;
+}

--- a/src/main/java/com/musai/musai/dto/difficulty/DifficultyResponseDTO.java
+++ b/src/main/java/com/musai/musai/dto/difficulty/DifficultyResponseDTO.java
@@ -1,0 +1,14 @@
+package com.musai.musai.dto.difficulty;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DifficultyResponseDTO {
+    private String convertedText;
+}

--- a/src/main/java/com/musai/musai/dto/user/SettingDTO.java
+++ b/src/main/java/com/musai/musai/dto/user/SettingDTO.java
@@ -1,0 +1,17 @@
+package com.musai.musai.dto.user;
+
+import com.musai.musai.entity.user.DefaultDifficulty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "설정 정보 조회")
+public class SettingDTO {
+    private Long userId;
+    private DefaultDifficulty defaultDifiiculty;
+    private Boolean allowCAlarm;
+    private Boolean allowRAlarm;
+}

--- a/src/main/java/com/musai/musai/entity/user/DefaultDifficulty.java
+++ b/src/main/java/com/musai/musai/entity/user/DefaultDifficulty.java
@@ -1,0 +1,7 @@
+package com.musai.musai.entity.user;
+
+public enum DefaultDifficulty {
+    EASY,
+    NORMAL,
+    HARD
+}

--- a/src/main/java/com/musai/musai/entity/user/Setting.java
+++ b/src/main/java/com/musai/musai/entity/user/Setting.java
@@ -1,0 +1,28 @@
+package com.musai.musai.entity.user;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "user_setting")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Setting {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "default_difficulty", nullable = false)
+    private DefaultDifficulty defaultDiffiiculty = DefaultDifficulty.NORMAL;
+
+    @Column(name = "allow_calarm", nullable = false)
+    private Boolean allowCalarm = true;
+
+    @Column(name = "allow_ralarm", nullable = false)
+    private Boolean allowRalarm = true;
+}

--- a/src/main/java/com/musai/musai/repository/user/SettingRepository.java
+++ b/src/main/java/com/musai/musai/repository/user/SettingRepository.java
@@ -1,0 +1,9 @@
+package com.musai.musai.repository.user;
+
+import com.musai.musai.entity.user.Setting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SettingRepository extends JpaRepository<Setting, Long> {
+}

--- a/src/main/java/com/musai/musai/service/RecogService.java
+++ b/src/main/java/com/musai/musai/service/RecogService.java
@@ -24,7 +24,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Service
 public class RecogService {
-    // FastAPI 서버 주소
+    // AI 서버 주소
     private static final String FAST_API_URL = "http://musai-ai:8000/web-detection/";
     private static final String LOCAL_API_URL = "http://localhost:8000/web-detection/";
     private final VuforiaService vuforiaService;

--- a/src/main/java/com/musai/musai/service/difficulty/DifficultyService.java
+++ b/src/main/java/com/musai/musai/service/difficulty/DifficultyService.java
@@ -1,0 +1,18 @@
+package com.musai.musai.service.difficulty;
+
+import com.musai.musai.entity.user.DefaultDifficulty;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DifficultyService {
+
+    // FastAPI 서버 주소
+    private static final String FAST_API_URL = "http://musai-ai:8000/web-detection/";
+    private static final String LOCAL_API_URL = "http://localhost:8000/web-detection/";
+
+    public String convert(DefaultDifficulty level, String original) {
+        return "변환된 텍스트";
+    }
+}

--- a/src/main/java/com/musai/musai/service/user/UserService.java
+++ b/src/main/java/com/musai/musai/service/user/UserService.java
@@ -1,8 +1,12 @@
 package com.musai.musai.service.user;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.musai.musai.dto.user.SettingDTO;
 import com.musai.musai.dto.user.UserDTO;
+import com.musai.musai.entity.user.DefaultDifficulty;
+import com.musai.musai.entity.user.Setting;
 import com.musai.musai.entity.user.User;
+import com.musai.musai.repository.user.SettingRepository;
 import com.musai.musai.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,6 +15,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final SettingRepository settingRepository;
 
     public User findOrCreateUserFromGoogle(GoogleIdToken.Payload payload) {
         String oauthProvider = "google";
@@ -31,7 +36,7 @@ public class UserService {
 
     public UserDTO getUserById(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+                .orElseThrow(() -> new RuntimeException("해당 유저가 없습니다."));
 
         return UserDTO.builder()
                 .userId(user.getUserId())
@@ -43,7 +48,7 @@ public class UserService {
 
     public UserDTO updateUser(Long userId, UserDTO userDTO) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+                .orElseThrow(() -> new RuntimeException("해당 유저가 없습니다."));
 
         //업데이트 할 정보
         user.setNickname(userDTO.getNickname());
@@ -55,6 +60,34 @@ public class UserService {
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .profileImage(user.getProfileImage())
+                .build();
+    }
+
+    public SettingDTO getSettingById(Long userId) {
+        Setting setting = settingRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("해당 유저가 없습니다."));
+
+        return SettingDTO.builder()
+                .userId(setting.getUserId())
+                .defaultDifiiculty(setting.getDefaultDiffiiculty())
+                .allowCAlarm(setting.getAllowCalarm())
+                .allowRAlarm(setting.getAllowRalarm())
+                .build();
+    }
+
+    public SettingDTO updateLevel(Long userId, DefaultDifficulty level) {
+        Setting setting = settingRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("해당 유저가 없습니다."));
+
+        //업데이트 정보
+        setting.setDefaultDiffiiculty(level);
+        settingRepository.save(setting);
+
+        return SettingDTO.builder()
+                .userId(setting.getUserId())
+                .defaultDifiiculty(setting.getDefaultDiffiiculty())
+                .allowCAlarm(setting.getAllowCalarm())
+                .allowRAlarm(setting.getAllowRalarm())
                 .build();
     }
 }


### PR DESCRIPTION
## 📌연관된 이슈 번호
#34 

## ✨PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x]  기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝작업 내용
1. 사용자 설정 조회 API 추가
2. 난이도별 해설 기본값 수정 API 추가
3. 해설 난이도 변경 API 기본 구조 추가

## 💬리뷰 포인트 (선택)
난이도별 해설 기본값 수정 API 유저 컨트롤러에 배치하긴 했는데, 보기 불편하면 컨트롤러 배치 수정할게요.

## 테스트 결과 (선택)
<img width="410" height="123" alt="image" src="https://github.com/user-attachments/assets/5d284731-7fac-4d09-9882-1d092efec9af" />
DB 값 변경