### PR TITLE
✨Feat: Add 사용자 관련 API 기능 추가

### DIFF
--- a/src/main/java/com/musai/musai/repository/user/UserRepository.java
+++ b/src/main/java/com/musai/musai/repository/user/UserRepository.java
@@ -11,4 +11,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByOauthId(String oauthId);
     Optional<User> findByEmail(String email);
     Optional<User> findByOauthProviderAndOauthId(String oauthProvider, String oauthId);
+
+    Optional<User> findByNickname(String nickname);
+    Optional<User> findByNicknameAndUserIdNot(String nickname, Long userId);
+    boolean existsByNickname(String nickname);
+    boolean existsByNicknameAndUserIdNot(String nickname, Long userId);
 }

--- a/src/main/java/com/musai/musai/service/user/UserService.java
+++ b/src/main/java/com/musai/musai/service/user/UserService.java
@@ -10,6 +10,7 @@ import com.musai.musai.repository.user.SettingRepository;
 import com.musai.musai.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +18,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final SettingRepository settingRepository;
 
+    @Transactional
     public User findOrCreateUserFromGoogle(GoogleIdToken.Payload payload) {
         String oauthProvider = "google";
         String oauthId = payload.getSubject();
@@ -25,13 +27,22 @@ public class UserService {
         String profileImage = (String) payload.get("picture");
 
         return userRepository.findByOauthProviderAndOauthId(oauthProvider, oauthId)
-                .orElseGet(() -> userRepository.save(User.builder()
+            .orElseGet(() -> {
+                User user = userRepository.save(User.builder()
                         .oauthProvider(oauthProvider)
                         .oauthId(oauthId)
                         .email(email)
                         .nickname(nickname)
                         .profileImage(profileImage)
-                        .build()));
+                        .build());
+                settingRepository.save(Setting.builder()
+                        .userId(user.getUserId())
+                        .defaultDiffiiculty(DefaultDifficulty.NORMAL)
+                        .allowCalarm(true)
+                        .allowRalarm(true)
+                        .build());
+                return user;
+            });
     }
 
     public UserDTO getUserById(Long userId) {
@@ -46,11 +57,35 @@ public class UserService {
                 .build();
     }
 
-    public UserDTO updateUser(Long userId, UserDTO userDTO) {
+    public void checkNickname(Long userId, String nickname) {
+        if (userId == null) {
+            // 회원가입 시: 전체에서 닉네임 중복 확인
+            if (userRepository.existsByNickname(nickname)) {
+                throw new RuntimeException("이미 사용 중인 닉네임입니다.");
+            }
+        } else {
+            if (!userRepository.existsById(userId)) {
+                throw new RuntimeException("해당 유저가 없습니다.");
+            }
+            
+            if (userRepository.existsByNicknameAndUserIdNot(nickname, userId)) {
+                throw new RuntimeException("이미 사용 중인 닉네임입니다.");
+            }
+        }
+    }
+
+    public UserDTO updateUser(UserDTO userDTO) {
+        Long userId = userDTO.getUserId();
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("해당 유저가 없습니다."));
 
-        //업데이트 할 정보
+        if (userDTO.getNickname() != null && !userDTO.getNickname().equals(user.getNickname())) {
+            if (userRepository.existsByNicknameAndUserIdNot(userDTO.getNickname(), userId)) {
+                throw new RuntimeException("이미 사용 중인 닉네임입니다.");
+            }
+        }
+
         user.setNickname(userDTO.getNickname());
         user.setProfileImage(userDTO.getProfileImage());
         userRepository.save(user);


### PR DESCRIPTION
## 📌연관된 이슈 번호
#42 

## ✨PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x]  기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝작업 내용
사용자와 관련된 기능 API 기능 추가했습니다.
1. 회원가입시, 유저 세팅 컬럼 자동 생성
2. 사용자 정보 수정시, 닉네임 중복 확인
3. 닉네임 중복 확인 API 추가

## 💬리뷰 포인트 (선택)

## 테스트 결과 (선택)
<img width="383" height="222" alt="image" src="https://github.com/user-attachments/assets/fc8904fc-4ed8-4a43-95f5-6b805e29fc1e" />

닉네임 중복 체크
