### PR TITLE
✨Feat: Add 티켓 관련 API 추가

### DIFF
--- a/src/main/java/com/musai/musai/controller/ticket/TicketController.java
+++ b/src/main/java/com/musai/musai/controller/ticket/TicketController.java
@@ -1,0 +1,54 @@
+package com.musai.musai.controller.ticket;
+
+import com.musai.musai.dto.ticket.TicketDTO;
+import com.musai.musai.service.ticket.TicketService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/ticket")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
+public class TicketController {
+
+    private final TicketService ticketService;
+
+    @Operation(summary = "티켓 목록 전체 조회", description = "티켓 리스트를 전체 조회합니다.")
+    @GetMapping("/readAll/{userId}")
+    public ResponseEntity<List<TicketDTO>> readTicketList(@PathVariable Long userId) {
+        List<TicketDTO> tickets = ticketService.getAllTicketsByUser(userId);
+        return ResponseEntity.ok(tickets);
+    }
+
+    @Operation(summary = "티켓 상세 조회", description = "티켓을 상세 조회합니다.")
+    @GetMapping("/read/{ticketId}")
+    public ResponseEntity<TicketDTO> readTicket(@PathVariable Long ticketId) {
+        TicketDTO ticket = ticketService.getTicket(ticketId);
+        if (ticket == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(ticket);
+    }
+
+    @Operation(summary = "티켓 추가", description = "티켓을 추가합니다.")
+    @PostMapping("/add")
+    public ResponseEntity<TicketDTO> addTicket(@RequestBody TicketDTO requestDTO) {
+        TicketDTO newTicket = ticketService.addTicket(requestDTO);
+        return ResponseEntity.ok(newTicket);
+    }
+
+    @Operation(summary = "티켓 삭제", description = "티켓을 삭제합니다.")
+    @DeleteMapping("/delete/{ticketId}")
+    public ResponseEntity<TicketDTO> deleteTicket(@PathVariable Long ticketId) {
+        TicketDTO ticket = ticketService.deleteTicket(ticketId);
+        if (ticket == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(ticket);
+    }
+}

--- a/src/main/java/com/musai/musai/dto/ticket/TicketDTO.java
+++ b/src/main/java/com/musai/musai/dto/ticket/TicketDTO.java
@@ -1,0 +1,41 @@
+package com.musai.musai.dto.ticket;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Data
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "티켓")
+public class TicketDTO {
+    @Schema(description = "티켓 고유 아이디", example = "1")
+    private Long ticketId;
+
+    @Schema(description = "사용자 고유 아이디", example = "1")
+    private Long userId;
+
+    @Schema(description = "티켓 생성 날짜", example = "2025-07-22T10:30:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "티켓 이미지", example = "ticket.jpg")
+    private String ticketImage;
+
+    @Schema(description = "작품명", example = "별이 빛나는 밤")
+    private String title;
+
+    @Schema(description = "작가명", example = "빈센트 반고흐")
+    private String artist;
+
+    @Schema(description = "전시관", example = "예술의 전당")
+    private String place;
+}

--- a/src/main/java/com/musai/musai/entity/ticket/Ticket.java
+++ b/src/main/java/com/musai/musai/entity/ticket/Ticket.java
@@ -1,0 +1,38 @@
+package com.musai.musai.entity.ticket;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ticket")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Ticket {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ticket_id")
+    private Long ticketId;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "ticket_image")
+    private String ticketImage;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "artist")
+    private String artist;
+
+    @Column(name = "place")
+    private String place;
+}

--- a/src/main/java/com/musai/musai/repository/ticket/TicketRepository.java
+++ b/src/main/java/com/musai/musai/repository/ticket/TicketRepository.java
@@ -1,0 +1,16 @@
+package com.musai.musai.repository.ticket;
+
+import com.musai.musai.entity.ticket.Ticket;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
+    
+    /**
+     * 사용자 ID로 티켓 목록 조회
+     */
+    List<Ticket> findByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/src/main/java/com/musai/musai/service/ticket/TicketService.java
+++ b/src/main/java/com/musai/musai/service/ticket/TicketService.java
@@ -1,0 +1,73 @@
+package com.musai.musai.service.ticket;
+
+import com.musai.musai.dto.ticket.TicketDTO;
+import com.musai.musai.entity.ticket.Ticket;
+import com.musai.musai.repository.ticket.TicketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TicketService {
+
+    private final TicketRepository ticketRepository;
+
+    @Transactional(readOnly = true)
+    public List<TicketDTO> getAllTicketsByUser(Long userId) {
+        List<Ticket> tickets = ticketRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        return tickets.stream()
+                .map(this::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public TicketDTO getTicket(Long ticketId) {
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElse(null);
+        return ticket != null ? toDTO(ticket) : null;
+    }
+
+    public TicketDTO addTicket(TicketDTO requestDTO) {
+        Ticket ticket = Ticket.builder()
+                .userId(requestDTO.getUserId())
+                .createdAt(LocalDateTime.now())
+                .ticketImage(requestDTO.getTicketImage())
+                .title(requestDTO.getTitle())
+                .artist(requestDTO.getArtist())
+                .place(requestDTO.getPlace())
+                .build();
+
+        Ticket savedTicket = ticketRepository.save(ticket);
+        return toDTO(savedTicket);
+    }
+
+    public TicketDTO deleteTicket(Long ticketId) {
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElse(null);
+        
+        if (ticket != null) {
+            ticketRepository.delete(ticket);
+            return toDTO(ticket);
+        }
+        return null;
+    }
+
+    private TicketDTO toDTO(Ticket ticket) {
+        return TicketDTO.builder()
+                .ticketId(ticket.getTicketId())
+                .userId(ticket.getUserId())
+                .createdAt(ticket.getCreatedAt())
+                .ticketImage(ticket.getTicketImage())
+                .title(ticket.getTitle())
+                .artist(ticket.getArtist())
+                .place(ticket.getPlace())
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 📌연관된 이슈 번호
#47 

## ✨PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ]  기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝작업 내용
1. 티켓 목록 조회
2. 티켓 상세 조회
3. 티켓 추가
4. 티켓 삭제
티켓 기능과 관련된 API 추가했습니다.

## 💬리뷰 포인트 (선택)

## 테스트 결과 (선택)
<img width="605" height="397" alt="image" src="https://github.com/user-attachments/assets/a0e4adab-d633-4859-b319-da691db61d45" />

스웨거로 리스트 조회

<img width="745" height="107" alt="image" src="https://github.com/user-attachments/assets/462182bd-3353-40ae-9a25-61627cbbc602" />


데이터베이스에 추가 및 삭제된 값 확인

