### PR TITLE
✨Feat: Add 사용자 설정과 관련된 API 추가

### DIFF
--- a/src/main/java/com/musai/musai/controller/user/UserController.java
+++ b/src/main/java/com/musai/musai/controller/user/UserController.java
@@ -1,5 +1,6 @@
 package com.musai.musai.controller.user;
 
+import com.musai.musai.dto.community.PostDTO;
 import com.musai.musai.dto.user.SettingDTO;
 import com.musai.musai.dto.user.UserDTO;
 import com.musai.musai.dto.user.UserErrorDTO;
@@ -15,6 +16,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Controller
 @RequestMapping("/user")
@@ -95,6 +98,14 @@ public class UserController {
         }
     }
 
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 진행합니다.")
+    @DeleteMapping("/delete/{userId}")
+    public ResponseEntity<UserDTO> deleteUser(
+            @PathVariable Long userId) {
+        UserDTO deleteUser = userService.deleteUser(userId);
+        return ResponseEntity.ok(deleteUser);
+    }
+
     @Operation(summary = "사용자 설정 조회", description = "사용자 설정 정보를 조회합니다..")
     @GetMapping("/setting/{userId}")
     public ResponseEntity<SettingDTO> readSetting (
@@ -110,5 +121,36 @@ public class UserController {
             @PathVariable DefaultDifficulty level) {
         SettingDTO updateSet = userService.updateLevel(userId, level);
         return ResponseEntity.ok(updateSet);
+    }
+
+    @Operation(summary = "추천 알림 상태 변경", description = "추천 알림을 on/off 합니다.")
+    @PutMapping("/alarm/recog/{userId}")
+    public ResponseEntity<SettingDTO> updateRecogAlarm(
+            @PathVariable Long userId) {
+        SettingDTO updateSet = userService.updateRecogAlarm(userId);
+        return ResponseEntity.ok(updateSet);
+    }
+
+    @Operation(summary = "커뮤니티 알림 상태 변경", description = "커뮤니티 알림을 on/off 합니다.")
+    @PutMapping("/alarm/community/{userId}")
+    public ResponseEntity<SettingDTO> updateCommunityAlarm(
+            @PathVariable Long userId) {
+        SettingDTO updateSet = userService.updateCommunityAlarm(userId);
+        return ResponseEntity.ok(updateSet);
+    }
+
+    @Operation(summary = "내가 쓴 게시글 조회", description = "사용자가 쓴 게시글을 조회합니다.")
+    @GetMapping("/post/{userId}")
+    public ResponseEntity<List<PostDTO>> myPost(
+            @PathVariable Long userId) {
+        List<PostDTO> posts = userService.myPost(userId);
+        return ResponseEntity.ok(posts);
+    }
+
+    @Operation(summary = "내가 작성한 댓글 조회", description = "사용자가 댓글을 작성한 게시글을 조회합니다.")
+    @GetMapping("/comment/{userId}")
+    public ResponseEntity<List<PostDTO>> myComment(@PathVariable Long userId) {
+        List<PostDTO> comments = userService.myComment(userId);
+        return ResponseEntity.ok(comments);
     }
 }

--- a/src/main/java/com/musai/musai/dto/community/CommentDTO.java
+++ b/src/main/java/com/musai/musai/dto/community/CommentDTO.java
@@ -1,5 +1,8 @@
 package com.musai.musai.dto.community;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
 import lombok.*;
@@ -13,6 +16,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "댓글")
 public class CommentDTO {
     @Schema(description = "댓글 고유 아이디", example = "1")
@@ -35,4 +39,24 @@ public class CommentDTO {
 
     @Schema(description = "답글 목록")
     private List<CommentDTO> replies;
+
+    @JsonCreator
+    public static CommentDTO create(
+            @JsonProperty("commentId") Long commentId,
+            @JsonProperty("userId") Long userId,
+            @JsonProperty("postId") Long postId,
+            @JsonProperty("parentCommentId") Long parentCommentId,
+            @JsonProperty("content") String content,
+            @JsonProperty("createdAt") LocalDateTime createdAt,
+            @JsonProperty("replies") List<CommentDTO> replies) {
+        return CommentDTO.builder()
+                .commentId(commentId)
+                .userId(userId)
+                .postId(postId)
+                .parentCommentId(parentCommentId)
+                .content(content)
+                .createdAt(createdAt)
+                .replies(replies)
+                .build();
+    }
 }

--- a/src/main/java/com/musai/musai/dto/user/SettingDTO.java
+++ b/src/main/java/com/musai/musai/dto/user/SettingDTO.java
@@ -11,7 +11,7 @@ import lombok.*;
 @Schema(description = "설정 정보 조회")
 public class SettingDTO {
     private Long userId;
-    private DefaultDifficulty defaultDifiiculty;
+    private DefaultDifficulty defaultDifficulty;
     private Boolean allowCAlarm;
     private Boolean allowRAlarm;
 }

--- a/src/main/java/com/musai/musai/repository/community/CommentRepository.java
+++ b/src/main/java/com/musai/musai/repository/community/CommentRepository.java
@@ -14,4 +14,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByPostId(Long postId);
     Page<Comment> findByPostId(Long postId, Pageable pageable);
     Optional<Comment> findByCommentId(Long commentId);
+    List<Comment> findByUserId(Long userId);
 }

--- a/src/main/java/com/musai/musai/repository/community/PostRepository.java
+++ b/src/main/java/com/musai/musai/repository/community/PostRepository.java
@@ -1,7 +1,11 @@
 package com.musai.musai.repository.community;
 
+import com.musai.musai.dto.community.PostDTO;
 import com.musai.musai.entity.community.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findByUserId(Long userId);
 }


### PR DESCRIPTION
## 📌연관된 이슈 번호
#59 

## ✨PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x]  기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝작업 내용
사용자 설정 기능과 관련된 API 추가했습니다.

1. 회원 탈퇴 API 추가
2. 추천 알림 on/off 변경 API 추가
3. 커뮤니티 알림 on/off 변경 API 추가
4. 내가 쓴 게시글 조회 API 추가
5. 내가 댓글 쓴 게시글 조회 API 추가

## 💬리뷰 포인트 (선택)

## 테스트 결과 (선택)
<img width="697" height="506" alt="image" src="https://github.com/user-attachments/assets/e7d46b16-58d4-4a0d-a0e6-b40f76ca7ef9" />

내가 쓴 게시글 조회

<img width="462" height="507" alt="image" src="https://github.com/user-attachments/assets/3d7be432-d5cd-4970-9001-2553f0287be5" />

내가 댓글 쓴 게시글 조회

<img width="510" height="290" alt="image" src="https://github.com/user-attachments/assets/ac49c4f5-283d-4ac2-af61-a0d358c5a05d" />
<img width="485" height="177" alt="image" src="https://github.com/user-attachments/assets/7c666927-37b5-4ef6-bb9f-fdf5da945aa0" />

알림 상태 변경