### PR TITLE
✨Feat: Add 공감 취소 및 공감 개수 조회 API 추가

### DIFF
--- a/src/main/java/com/musai/musai/controller/community/LikeController.java
+++ b/src/main/java/com/musai/musai/controller/community/LikeController.java
@@ -30,13 +30,6 @@ public class LikeController {
         }
     }
 
-    @Operation(summary = "공감 조회", description = "내가 공감한 게시글을 조회합니다.")
-    @GetMapping("/{userId}")
-    public ResponseEntity<List<Like>> getLikesByUser(@RequestParam Long userId) {
-        List<Like> likes = likeService.getLikesByUserId(userId);
-        return ResponseEntity.ok(likes);
-    }
-
     @Operation(summary = "공감 취소", description = "공감을 취소합니다.")
     @DeleteMapping("/delete")
     public ResponseEntity<String> deleteLike(@RequestBody LikeDTO dto) {

--- a/src/main/java/com/musai/musai/controller/community/LikeController.java
+++ b/src/main/java/com/musai/musai/controller/community/LikeController.java
@@ -3,13 +3,14 @@ package com.musai.musai.controller.community;
 import com.musai.musai.dto.community.LikeDTO;
 import com.musai.musai.entity.community.Like;
 import com.musai.musai.service.community.LikeService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/likes")
+@RequestMapping("/like")
 public class LikeController {
 
     private final LikeService likeService;
@@ -18,19 +19,32 @@ public class LikeController {
         this.likeService = likeService;
     }
 
-    @PostMapping
+    @Operation(summary = "공감 등록", description = "게시글에 공감을 추가합니다.")
+    @PostMapping("/add")
     public ResponseEntity<String> addLike(@RequestBody LikeDTO dto) {
         try {
             Like savedLike = likeService.addLike(dto);
-            return ResponseEntity.ok("좋아요가 등록되었습니다. likeId: " + savedLike.getId());
+            return ResponseEntity.ok("공감이 등록되었습니다. likeId: " + savedLike.getId());
         } catch (IllegalStateException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
     }
 
-    @GetMapping("/user")
+    @Operation(summary = "공감 조회", description = "내가 공감한 게시글을 조회합니다.")
+    @GetMapping("/{userId}")
     public ResponseEntity<List<Like>> getLikesByUser(@RequestParam Long userId) {
         List<Like> likes = likeService.getLikesByUserId(userId);
         return ResponseEntity.ok(likes);
+    }
+
+    @Operation(summary = "공감 취소", description = "공감을 취소합니다.")
+    @DeleteMapping("/delete")
+    public ResponseEntity<String> deleteLike(@RequestBody LikeDTO dto) {
+        try {
+            Like deleteLikes = likeService.deleteLike(dto.getPostId(), dto.getUserId());
+            return ResponseEntity.ok("공감이 취소되었습니다.");
+        } catch (IllegalStateException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/musai/musai/controller/community/PostController.java
+++ b/src/main/java/com/musai/musai/controller/community/PostController.java
@@ -2,6 +2,7 @@ package com.musai.musai.controller.community;
 
 import com.musai.musai.dto.community.PostDTO;
 import com.musai.musai.service.community.PostService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +21,7 @@ public class PostController {
         this.postService = postService;
     }
 
-    //글 작성
+    @Operation(summary = "게시글 작성", description = "게시글을 작성합니다.")
     @PostMapping("/add")
     public ResponseEntity<PostDTO> createPost(@RequestBody PostDTO postDto) {
         PostDTO createdPost = postService.createPost(postDto);
@@ -28,28 +29,28 @@ public class PostController {
         //반환값 postDto로 반환 부탁!
     }
 
-    //게시글 삭제
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
     @DeleteMapping("/delete/{postId}")
     public ResponseEntity<?> deletePost(@PathVariable Long postId) {
         postService.deletePost(postId);
         return ResponseEntity.ok("게시물 삭제 성공");
     }
 
-    //전체 게시글 조회
-    @GetMapping("/all")
+    @Operation(summary = "게시글 조회", description = "게시글을 조회합니다.")
+    @GetMapping("/readAll")
     public ResponseEntity<List<PostDTO>> getAllPosts() {
         List<PostDTO> postList = postService.getAllPosts();
         return ResponseEntity.ok(postList);
     }
 
-    //게시글 상세 조회(id로)
+    @Operation(summary = "게시글 상세 조회", description = "게시글을 상세 조회합니다.")
     @GetMapping("/detail/{postId}")
     public ResponseEntity<PostDTO> getPostDetail(@PathVariable Long postId) {
         PostDTO postDto = postService.getPostById(postId);
         return ResponseEntity.ok(postDto);
     }
 
-    //게시글 수정
+    @Operation(summary = "게시글 수정", description = "게시글을 수정합니다.")
     @PutMapping("/update/{postId}")
     public ResponseEntity<PostDTO> updatePost(
             @PathVariable Long postId,
@@ -58,7 +59,7 @@ public class PostController {
         return ResponseEntity.ok(updatedPost);
     }
 
-    //게시물 검색
+    @Operation(summary = "게시글 검색", description = "게시글을 검색합니다.")
     @GetMapping("/search")
     public ResponseEntity<List<PostDTO>> searchPosts(@RequestParam String keyword) {
         List<PostDTO> searchResults = postService.searchPosts(keyword);

--- a/src/main/java/com/musai/musai/dto/community/PostDTO.java
+++ b/src/main/java/com/musai/musai/dto/community/PostDTO.java
@@ -17,6 +17,7 @@ public class PostDTO {
     private String image4;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private Long likeCount;
 
     public static PostDTO fromEntity(Post post) {
         PostDTO dto = new PostDTO();
@@ -30,6 +31,13 @@ public class PostDTO {
         dto.setImage4(post.getImage4());
         dto.setCreatedAt(post.getCreatedAt());
         dto.setUpdatedAt(post.getUpdatedAt());
+        return dto;
+    }
+
+    // 공감 개수를 포함한 fromEntity 메서드 오버로드
+    public static PostDTO fromEntity(Post post, Long likeCount) {
+        PostDTO dto = fromEntity(post);
+        dto.setLikeCount(likeCount);
         return dto;
     }
 }

--- a/src/main/java/com/musai/musai/repository/community/LikeRepository.java
+++ b/src/main/java/com/musai/musai/repository/community/LikeRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
     boolean existsByPostIdAndUserId(Long postId, Long userId);
     List<Like> findAllByUserId(Long userId);
+    Optional<Like> findByPostIdAndUserId(Long postId, Long userId);
+    void deleteByPostIdAndUserId(Long postId, Long userId);
 }

--- a/src/main/java/com/musai/musai/repository/community/LikeRepository.java
+++ b/src/main/java/com/musai/musai/repository/community/LikeRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
     boolean existsByPostIdAndUserId(Long postId, Long userId);
-    List<Like> findAllByUserId(Long userId);
     Optional<Like> findByPostIdAndUserId(Long postId, Long userId);
     void deleteByPostIdAndUserId(Long postId, Long userId);
+    Long countByPostId(Long postId);
 }

--- a/src/main/java/com/musai/musai/service/community/LikeService.java
+++ b/src/main/java/com/musai/musai/service/community/LikeService.java
@@ -33,9 +33,8 @@ public class LikeService {
         return likeRepository.save(postLike);
     }
 
-    //공감 조회
-    public List<Like> getLikesByUserId(Long userId) {
-        return likeRepository.findAllByUserId(userId);
+    public Long getLikeCountByPostId(Long postId) {
+        return likeRepository.countByPostId(postId);
     }
 
     @Transactional

--- a/src/main/java/com/musai/musai/service/community/LikeService.java
+++ b/src/main/java/com/musai/musai/service/community/LikeService.java
@@ -37,4 +37,14 @@ public class LikeService {
     public List<Like> getLikesByUserId(Long userId) {
         return likeRepository.findAllByUserId(userId);
     }
+
+    @Transactional
+    public Like deleteLike(Long postId, Long userId) {
+        Like existingLike = likeRepository.findByPostIdAndUserId(postId, userId)
+                .orElseThrow(() -> new IllegalStateException("해당 게시물에 등록된 공감이 없습니다."));
+
+        likeRepository.deleteByPostIdAndUserId(postId, userId);
+        
+        return existingLike;
+    }
 }


### PR DESCRIPTION
## 📌연관된 이슈 번호
#51 

## ✨PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x]  기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝작업 내용
공감과 관련된 API 수정

1. 공감 취소 API 추가
2. 게시글 조회시, 공감 개수까지 반환하는 API로 수정
3. 스웨거 API 설명 추가

## 💬리뷰 포인트 (선택)

## 테스트 결과 (선택)
<img width="527" height="526" alt="image" src="https://github.com/user-attachments/assets/70948b00-40b4-4573-a83b-569d76152a23" />

게시글 조회와 동시에 공감 개수 반환
