### PR TITLE
🐛Bug: Update 게시글 삭제 시, 오류 수정

### DIFF
--- a/src/main/java/com/musai/musai/repository/community/CommentRepository.java
+++ b/src/main/java/com/musai/musai/repository/community/CommentRepository.java
@@ -16,4 +16,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Optional<Comment> findByCommentId(Long commentId);
     List<Comment> findByUserId(Long userId);
     Long countByPostId(Long postId);
+    void deleteByPostId(Long postId);
+    void deleteByPostIdAndParentCommentIdIsNotNull(Long postId);
+    void deleteByPostIdAndParentCommentIdIsNull(Long postId);
 }

--- a/src/main/java/com/musai/musai/repository/community/LikeRepository.java
+++ b/src/main/java/com/musai/musai/repository/community/LikeRepository.java
@@ -13,4 +13,5 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     Optional<Like> findByPostIdAndUserId(Long postId, Long userId);
     void deleteByPostIdAndUserId(Long postId, Long userId);
     Long countByPostId(Long postId);
+    void deleteByPostId(Long postId);
 }

--- a/src/main/java/com/musai/musai/service/community/CommentService.java
+++ b/src/main/java/com/musai/musai/service/community/CommentService.java
@@ -157,9 +157,6 @@ public class CommentService {
         return commentRepository.countByPostId(postId);
     }
 
-    /**
-     * 답글의 레벨을 계산합니다 (1번째 답글, 2번째 답글 등)
-     */
     private int calculateReplyLevel(Long parentCommentId) {
         int level = 1;
         Long currentParentId = parentCommentId;
@@ -174,6 +171,12 @@ public class CommentService {
         }
         
         return level;
+    }
+
+    @Transactional
+    public void deleteAllByPostId(Long postId) {
+        commentRepository.deleteByPostIdAndParentCommentIdIsNotNull(postId);
+        commentRepository.deleteByPostIdAndParentCommentIdIsNull(postId);
     }
 
     private CommentDTO toDTO(Comment comment) {

--- a/src/main/java/com/musai/musai/service/community/LikeService.java
+++ b/src/main/java/com/musai/musai/service/community/LikeService.java
@@ -17,10 +17,8 @@ public class LikeService {
         this.likeRepository = likeRepository;
     }
 
-    //공감 추가
     @Transactional
     public Like addLike(LikeDTO dto) {
-        // 중복 좋아요 방지
         if (likeRepository.existsByPostIdAndUserId(dto.getPostId(), dto.getUserId())) {
             throw new IllegalStateException("이미 좋아요가 등록된 게시물입니다.");
         }
@@ -45,5 +43,10 @@ public class LikeService {
         likeRepository.deleteByPostIdAndUserId(postId, userId);
         
         return existingLike;
+    }
+
+    @Transactional
+    public void deleteAllByPostId(Long postId) {
+        likeRepository.deleteByPostId(postId);
     }
 }

--- a/src/main/java/com/musai/musai/service/community/PostService.java
+++ b/src/main/java/com/musai/musai/service/community/PostService.java
@@ -45,6 +45,9 @@ public class PostService {
         if(!postRepository.existsById(postId)){
             throw new IllegalArgumentException("포스트 아이디 " + postId + " 없음");
         }
+
+        likeService.deleteAllByPostId(postId);
+        commentService.deleteAllByPostId(postId);
         postRepository.deleteById(postId);
     }
 


### PR DESCRIPTION
## 📌연관된 이슈 번호
#51 

## ✨PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ]  기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝작업 내용
게시글 삭제 시, 외래키 제약 오류 수정했습니다.
좋아요, 답글, 댓글 전부 같이 삭제되도록 수정했습니다.

## 💬리뷰 포인트 (선택)

## 테스트 결과 (선택)
<img width="385" height="267" alt="image" src="https://github.com/user-attachments/assets/1dff293f-4a5f-450b-bcd8-49fb7b26b429" />
삭제 성공 
