### PR TITLE
✨Feat: Update AR API 수정

### DIFF
--- a/src/main/java/com/musai/musai/controller/ar/ARController.java
+++ b/src/main/java/com/musai/musai/controller/ar/ARController.java
@@ -1,6 +1,9 @@
 package com.musai.musai.controller.ar;
 
 import com.musai.musai.dto.ar.ARResponseDTO;
+import com.musai.musai.dto.ar.ArtworkUpdateDTO;
+import com.musai.musai.dto.ar.VuforiaRegisterResponseDTO;
+import com.musai.musai.entity.ar.Point;
 import com.musai.musai.service.ar.ARService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -16,20 +19,106 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Slf4j
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/ar")
+@RequiredArgsConstructor
 @SecurityRequirement(name = "bearerAuth")
 public class ARController {
 
     private final ARService arService;
 
-    @Operation(summary = "AR 해설", description = "이미지 파일을 받아서 AI로 분석하여 AR 해설, 좌표값, target_id를 반환합니다.")
+    @Operation(summary = "뷰포리아 이미지 등록", description = "이미지를 뷰포리아에 등록하고 target_id를 발급받아 DB에 저장합니다.")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
-                    description = "AR 해설 조회 성공",
+                    description = "작품 등록 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = VuforiaRegisterResponseDTO.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = VuforiaRegisterResponseDTO.class)
+                    )
+            )
+    })
+    @PostMapping(value = "/vuforia/register", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<VuforiaRegisterResponseDTO> registerArtwork(
+            @Parameter(description = "등록할 이미지 파일", required = true)
+            @RequestParam("file") MultipartFile file,
+            @Parameter(description = "작품 제목", required = true)
+            @RequestParam("title") String title) {
+        
+        try {
+            log.info("작품 등록 요청: title={}, filename={}", title, file.getOriginalFilename());
+            
+            if (file.isEmpty()) {
+                return ResponseEntity.badRequest()
+                        .body(VuforiaRegisterResponseDTO.error("이미지 파일이 비어있습니다."));
+            }
+
+            String targetId = arService.registerArtwork(file, title);
+            
+            return ResponseEntity.ok(VuforiaRegisterResponseDTO.success(targetId, title));
+            
+        } catch (Exception e) {
+            log.error("작품 등록 실패: {}", e.getMessage(), e);
+            return ResponseEntity.badRequest()
+                    .body(VuforiaRegisterResponseDTO.error("작품 등록 실패: " + e.getMessage()));
+        }
+    }
+
+    @Operation(summary = "AI 서버에서 메타데이터 받아오기", description = "AI 서버에 이미지를 전송하여 좌표와 해설을 받아와서 DB에 저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "AI 서버에서 메타데이터 받아오기 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = java.util.List.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (target_id를 찾을 수 없음)"
+            )
+    })
+    @PostMapping(value = "/points/ai-update", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<List<Point>> updateArtworkMetadataFromAI(
+            @Parameter(description = "뷰포리아 target_id", required = true)
+            @RequestParam("target_id") String targetId,
+            @Parameter(description = "AI 분석용 이미지 파일", required = true)
+            @RequestParam("file") MultipartFile file) {
+        
+        try {
+            log.info("AI 서버에서 메타데이터 받아오기 요청: target_id={}, filename={}", targetId, file.getOriginalFilename());
+            
+            if (file.isEmpty()) {
+                return ResponseEntity.badRequest().body(List.of());
+            }
+            
+            List<com.musai.musai.entity.ar.Point> savedPoints = arService.updateArtworkMetadataFromAI(targetId, file);
+            
+            return ResponseEntity.ok(savedPoints);
+            
+        } catch (Exception e) {
+            log.error("AI 서버에서 메타데이터 받아오기 실패: {}", e.getMessage(), e);
+            return ResponseEntity.badRequest().body(List.of());
+        }
+    }
+
+    @Operation(summary = "AR 데이터 조회", description = "target_id로 좌표와 설명을 조회하여 유니티에 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "AR 데이터 조회 성공",
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ARResponseDTO.class)
@@ -37,55 +126,24 @@ public class ARController {
             ),
             @ApiResponse(
                     responseCode = "400",
-                    description = "잘못된 요청 (이미지 파일 없음)",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = String.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "415",
-                    description = "지원하지 않는 이미지 형식",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = String.class)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "500",
-                    description = "서버 오류",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = String.class)
-                    )
+                    description = "잘못된 요청 (target_id를 찾을 수 없음)"
             )
     })
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ARResponseDTO> getARDescription(
-            @Parameter(description = "분석할 이미지 파일", required = true)
-            @RequestParam("file") MultipartFile file,
-            @Parameter(description = "작품 제목", required = true)
-            @RequestParam(value = "title", required = true) String title) {
+    @GetMapping
+    public ResponseEntity<ARResponseDTO> getARData(
+            @Parameter(description = "뷰포리아 target_id", required = true)
+            @RequestParam("target_id") String targetId) {
         
         try {
-            log.info("AR 해설 요청 수신: filename={}, size={}, title={}", 
-                    file.getOriginalFilename(), file.getSize(), title);
+            log.info("AR 데이터 조회 요청: target_id={}", targetId);
             
-            if (file.isEmpty()) {
-                return ResponseEntity.badRequest().build();
-            }
-
-            String contentType = file.getContentType();
-            if (contentType == null || (!contentType.equals("image/jpeg") && !contentType.equals("image/png"))) {
-                return ResponseEntity.status(415).build();
-            }
+            ARResponseDTO arData = arService.getARDataByTargetId(targetId);
             
-            ARResponseDTO responseDTO = arService.getARDescription(file, title);
-            return ResponseEntity.ok(responseDTO);
+            return ResponseEntity.ok(arData);
             
         } catch (Exception e) {
-            log.error("AR 해설 조회 실패: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError().build();
+            log.error("AR 데이터 조회 실패: {}", e.getMessage(), e);
+            return ResponseEntity.badRequest().build();
         }
     }
 }

--- a/src/main/java/com/musai/musai/controller/recog/VuforiaController.java
+++ b/src/main/java/com/musai/musai/controller/recog/VuforiaController.java
@@ -28,8 +28,8 @@ public class VuforiaController {
     private final VuforiaService vuforiaService;
     private final ObjectMapper objectMapper;
 
-    @Operation(summary = "Vuforia 이미지 등록", description = "이미지 파일을 multipart/form-data 형식으로 업로드하여 Vuforia 타겟을 등록합니다.")
-    @PostMapping(value = "/vuforia/register", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "Vuforia 이미지 등록 (기존)", description = "이미지 파일을 multipart/form-data 형식으로 업로드하여 Vuforia 타겟을 등록합니다.")
+    @PostMapping(value = "/vuforia/register-old", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<VuforiaResponseDTO> registerTarget(
             @Parameter(description = "업로드할 이미지 파일", required = true,
                     content = @Content(mediaType = MediaType.APPLICATION_OCTET_STREAM_VALUE,
@@ -42,8 +42,7 @@ public class VuforiaController {
             byte[] imageBytes = file.getBytes();
 
             String result = vuforiaService.registerTarget(imageName, imageBytes, metadata);
-            
-            // JSON 응답에서 target_id 추출
+
             JsonNode jsonNode = objectMapper.readTree(result);
             String targetId = jsonNode.path("target_id").asText();
             

--- a/src/main/java/com/musai/musai/dto/ar/ArtworkUpdateDTO.java
+++ b/src/main/java/com/musai/musai/dto/ar/ArtworkUpdateDTO.java
@@ -1,0 +1,38 @@
+package com.musai.musai.dto.ar;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "작품 업데이트 요청")
+public class ArtworkUpdateDTO {
+    
+    @Schema(description = "뷰포리아 target_id", example = "934847901755009590324", required = true)
+    private String targetId;
+    
+    @Schema(description = "AR 포인트 목록", required = true)
+    private List<PointDTO> points;
+    
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "포인트 정보")
+    public static class PointDTO {
+        
+        @Schema(description = "X 좌표 (0~1 정규화)", example = "0.5", required = true)
+        private BigDecimal x;
+        
+        @Schema(description = "Y 좌표 (0~1 정규화)", example = "0.3", required = true)
+        private BigDecimal y;
+        
+        @Schema(description = "AR 해설", example = "핵심 포인트: 내용 요약", required = true)
+        private String description;
+    }
+}

--- a/src/main/java/com/musai/musai/dto/ar/VuforiaRegisterResponseDTO.java
+++ b/src/main/java/com/musai/musai/dto/ar/VuforiaRegisterResponseDTO.java
@@ -1,0 +1,33 @@
+package com.musai.musai.dto.ar;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "뷰포리아 등록 응답")
+public class VuforiaRegisterResponseDTO {
+    
+    @Schema(description = "응답 성공 여부", example = "true")
+    private boolean success;
+    
+    @Schema(description = "뷰포리아 target_id", example = "934847901755009590324")
+    private String targetId;
+    
+    @Schema(description = "작품 제목", example = "모나리자")
+    private String title;
+    
+    @Schema(description = "응답 메시지", example = "작품이 성공적으로 등록되었습니다.")
+    private String message;
+    
+    public static VuforiaRegisterResponseDTO success(String targetId, String title) {
+        return new VuforiaRegisterResponseDTO(true, targetId, title, "작품이 성공적으로 등록되었습니다.");
+    }
+    
+    public static VuforiaRegisterResponseDTO error(String message) {
+        return new VuforiaRegisterResponseDTO(false, null, null, message);
+    }
+}

--- a/src/main/java/com/musai/musai/entity/ar/ArArt.java
+++ b/src/main/java/com/musai/musai/entity/ar/ArArt.java
@@ -1,0 +1,27 @@
+package com.musai.musai.entity.ar;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Entity
+@Table(name = "ar_art")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ArArt {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "art_id")
+    private Long artId;
+    
+    @Column(name = "title", nullable = false)
+    private String title;
+    
+    @Column(name = "target_id", nullable = false, unique = true)
+    private String targetId;
+}

--- a/src/main/java/com/musai/musai/entity/ar/Point.java
+++ b/src/main/java/com/musai/musai/entity/ar/Point.java
@@ -1,0 +1,35 @@
+package com.musai.musai.entity.ar;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "points")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Point {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "art_id", nullable = false)
+    private ArArt arArt;
+    
+    @Column(name = "x", nullable = false, precision = 5, scale = 4)
+    private BigDecimal x;
+    
+    @Column(name = "y", nullable = false, precision = 5, scale = 4)
+    private BigDecimal y;
+    
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+}

--- a/src/main/java/com/musai/musai/repository/ar/ArArtRepository.java
+++ b/src/main/java/com/musai/musai/repository/ar/ArArtRepository.java
@@ -1,0 +1,15 @@
+package com.musai.musai.repository.ar;
+
+import com.musai.musai.entity.ar.ArArt;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ArArtRepository extends JpaRepository<ArArt, Long> {
+    
+    Optional<ArArt> findByTargetId(String targetId);
+    
+    boolean existsByTargetId(String targetId);
+}

--- a/src/main/java/com/musai/musai/repository/ar/PointRepository.java
+++ b/src/main/java/com/musai/musai/repository/ar/PointRepository.java
@@ -1,0 +1,15 @@
+package com.musai.musai.repository.ar;
+
+import com.musai.musai.entity.ar.Point;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PointRepository extends JpaRepository<Point, Long> {
+    
+    List<Point> findByArArt_ArtId(Long artId);
+    
+    void deleteByArArt_ArtId(Long artId);
+}

--- a/src/main/java/com/musai/musai/service/ar/ARService.java
+++ b/src/main/java/com/musai/musai/service/ar/ARService.java
@@ -1,18 +1,28 @@
 package com.musai.musai.service.ar;
 
 import com.musai.musai.dto.ar.ARResponseDTO;
+import com.musai.musai.dto.ar.ArtworkUpdateDTO;
 import com.musai.musai.service.recog.VuforiaService;
+import com.musai.musai.entity.ar.ArArt;
+import com.musai.musai.entity.ar.Point;
+import com.musai.musai.repository.ar.ArArtRepository;
+import com.musai.musai.repository.ar.PointRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.http.*;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.multipart.MultipartFile;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -20,91 +30,109 @@ import java.util.List;
 public class ARService {
 
     private final VuforiaService vuforiaService;
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final ArArtRepository arArtRepository;
+    private final PointRepository pointRepository;
+    private final RestTemplate restTemplate;
 
     private static final String AI_SERVER_AR_URL = "http://musai-ai:8000/ar/points-gemini";
     private static final String LOCAL_SERVER_AR_URL = "http://localhost:8000/ar/points-gemini";
 
-    public ARResponseDTO getARDescription(MultipartFile file, String title) throws Exception {
-        log.info("AR 해설 요청: filename={}, size={}, title={}", 
-                file.getOriginalFilename(), file.getSize(), title);
+    public String registerArtwork(MultipartFile image, String title) throws Exception {
+        log.info("작품 등록 시작: title={}, filename={}", title, image.getOriginalFilename());
 
-		List<ARResponseDTO.ARPoint> aiPoints = getARDescriptionFromAIServer(file);
-
-		String targetId;
-		try {
-			String metadata = title;
-			targetId = vuforiaService.ensureTargetByTitle(title, file.getBytes(), metadata);
-			log.info("뷰포리아 타겟 확보: title={}, target_id={}", title, targetId);
-		} catch (Exception e) {
-			log.warn("뷰포리아 타겟 확보 실패: {}", e.getMessage(), e);
-			targetId = "temp_" + System.currentTimeMillis();
-		}
-
-        ARResponseDTO responseDTO = new ARResponseDTO();
-        responseDTO.setTarget_id(targetId);
-        responseDTO.setPoints(aiPoints);
+        String vuforiaResponse = vuforiaService.registerTarget(title, image.getBytes(), null);
+        String targetId = extractTargetIdFromResponse(vuforiaResponse);
         
-        log.info("AR 해설 응답 완성: target_id={}, points_count={}", 
-                responseDTO.getTarget_id(), 
-                responseDTO.getPoints() != null ? responseDTO.getPoints().size() : 0);
+        if (targetId == null || targetId.isEmpty()) {
+            throw new RuntimeException("뷰포리아에서 target_id를 받지 못했습니다.");
+        }
+
+        ArArt arArt = ArArt.builder()
+                .title(title)
+                .targetId(targetId)
+                .build();
+        arArtRepository.save(arArt);
         
-        return responseDTO;
+        log.info("작품 등록 완료: title={}, target_id={}", title, targetId);
+        return targetId;
     }
 
-    private List<ARResponseDTO.ARPoint> getARDescriptionFromAIServer(MultipartFile file) throws Exception {
-        try {
-            ByteArrayResource imageAsResource = new ByteArrayResource(file.getBytes()) {
-                @Override
-                public String getFilename() {
-                    return file.getOriginalFilename();
-                }
-            };
+    @Transactional
+    public List<Point> updateArtworkMetadataFromAI(String targetId, MultipartFile image) throws Exception {
+        log.info("AI 서버에서 메타데이터 받아오기 시작: target_id={}", targetId);
 
-            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-            body.add("file", imageAsResource);
+        ArArt arArt = arArtRepository.findByTargetId(targetId)
+                .orElseThrow(() -> new RuntimeException("해당 target_id를 가진 작품을 찾을 수 없습니다: " + targetId));
 
-            HttpHeaders headers = new HttpHeaders();
-            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        List<ARResponseDTO.ARPoint> aiPoints = getARDescriptionFromAIServer(image);
+        
+        if (aiPoints != null && !aiPoints.isEmpty()) {
+            pointRepository.deleteByArArt_ArtId(arArt.getArtId());
 
-            HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
-
-            //매번 바꿔야 됨
-            String aiServerUrl = AI_SERVER_AR_URL;
-
-            ResponseEntity<List> response = restTemplate.postForEntity(
-                    aiServerUrl,
-                    requestEntity,
-                    List.class
-            );
+            List<Point> points = aiPoints.stream()
+                    .map(aiPoint -> Point.builder()
+                            .arArt(arArt)
+                            .x(java.math.BigDecimal.valueOf(aiPoint.getX()))
+                            .y(java.math.BigDecimal.valueOf(aiPoint.getY()))
+                            .description(aiPoint.getDescription())
+                            .build())
+                    .collect(Collectors.toList());
             
-            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
-                log.info("AI 서버에서 AR 정보 수신 성공: points_count={}", response.getBody().size());
-
-                List<ARResponseDTO.ARPoint> points = response.getBody().stream()
-                        .map(this::convertMapToARPoint)
-                        .toList();
-                
-                return points;
-            } else {
-                throw new RuntimeException("AI 서버 응답 오류: " + response.getStatusCode());
-            }
-            
-        } catch (Exception e) {
-            log.error("AI 서버 AR API 호출 실패: {}", e.getMessage(), e);
-
-            log.warn("AI 서버 연결 실패로 임시 데이터 반환");
-
-            ARResponseDTO.ARPoint tempPoint = new ARResponseDTO.ARPoint();
-            tempPoint.setId("pt1");
-            tempPoint.setX(0.5);
-            tempPoint.setY(0.5);
-            tempPoint.setDescription("작품: AI 서버 연결 실패로 인한 임시 해설입니다. 파일: " + file.getOriginalFilename());
-            
-            return List.of(tempPoint);
+            pointRepository.saveAll(points);
+            log.info("AI 서버에서 받은 포인트 저장 완료: points_count={}", points.size());
+            return points;
+        } else {
+            log.warn("AI 서버에서 포인트를 받지 못했습니다.");
+            return List.of();
         }
     }
 
+    public ARResponseDTO getARDataByTargetId(String targetId) {
+        log.info("AR 데이터 조회 시작: target_id={}", targetId);
+
+        ArArt arArt = arArtRepository.findByTargetId(targetId)
+                .orElseThrow(() -> new RuntimeException("해당 target_id를 가진 작품을 찾을 수 없습니다: " + targetId));
+
+        List<Point> points = pointRepository.findByArArt_ArtId(arArt.getArtId());
+
+        ARResponseDTO responseDTO = new ARResponseDTO();
+        responseDTO.setTarget_id(targetId);
+        
+        List<ARResponseDTO.ARPoint> arPoints = points.stream()
+                .map(this::convertToARPoint)
+                .collect(Collectors.toList());
+        
+        responseDTO.setPoints(arPoints);
+        
+        log.info("AR 데이터 조회 완료: target_id={}, points_count={}", targetId, arPoints.size());
+        return responseDTO;
+    }
+
+    private String extractTargetIdFromResponse(String vuforiaResponse) {
+        try {
+            if (vuforiaResponse.contains("\"target_id\":")) {
+                int startIndex = vuforiaResponse.indexOf("\"target_id\":") + 13;
+                int endIndex = vuforiaResponse.indexOf("\"", startIndex);
+                if (endIndex > startIndex) {
+                    return vuforiaResponse.substring(startIndex, endIndex);
+                }
+            }
+            return null;
+        } catch (Exception e) {
+            log.error("뷰포리아 응답에서 target_id 추출 실패: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private ARResponseDTO.ARPoint convertToARPoint(Point point) {
+        ARResponseDTO.ARPoint arPoint = new ARResponseDTO.ARPoint();
+        arPoint.setId("pt" + point.getId());
+        arPoint.setX(point.getX().doubleValue());
+        arPoint.setY(point.getY().doubleValue());
+        arPoint.setDescription(point.getDescription());
+        return arPoint;
+    }
+    
     @SuppressWarnings("unchecked")
     private ARResponseDTO.ARPoint convertMapToARPoint(Object obj) {
         if (obj instanceof java.util.Map) {
@@ -138,4 +166,59 @@ public class ARService {
         defaultPoint.setDescription("작품: 응답 변환 실패");
         return defaultPoint;
     }
+
+    private List<ARResponseDTO.ARPoint> getARDescriptionFromAIServer(MultipartFile file) throws Exception {
+        try {
+            ByteArrayResource imageAsResource = new ByteArrayResource(file.getBytes()) {
+                @Override
+                public String getFilename() {
+                    return file.getOriginalFilename();
+                }
+            };
+
+            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+            body.add("file", imageAsResource);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+            HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
+
+            String aiServerUrl = AI_SERVER_AR_URL;
+
+            ResponseEntity<List> response = restTemplate.postForEntity(
+                    aiServerUrl,
+                    requestEntity,
+                    List.class
+            );
+            
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                List<Object> pointsList = response.getBody();
+                log.info("AI 서버에서 AR 정보 수신 성공: points_count={}", pointsList.size());
+
+                List<ARResponseDTO.ARPoint> points = pointsList.stream()
+                        .map(this::convertMapToARPoint)
+                        .toList();
+                
+                return points;
+            } else {
+                throw new RuntimeException("AI 서버 응답 오류: " + response.getStatusCode());
+            }
+            
+        } catch (Exception e) {
+            log.error("AI 서버 AR API 호출 실패: {}", e.getMessage(), e);
+
+            log.warn("AI 서버 연결 실패로 임시 데이터 반환");
+
+            ARResponseDTO.ARPoint tempPoint = new ARResponseDTO.ARPoint();
+            tempPoint.setId("pt1");
+            tempPoint.setX(0.5);
+            tempPoint.setY(0.5);
+            tempPoint.setDescription("작품: AI 서버 연결 실패로 인한 임시 해설입니다. 파일: " + file.getOriginalFilename());
+            
+            return List.of(tempPoint);
+        }
+    }
+
+
 }

--- a/src/main/java/com/musai/musai/service/recog/VuforiaService.java
+++ b/src/main/java/com/musai/musai/service/recog/VuforiaService.java
@@ -40,7 +40,9 @@ public class VuforiaService {
         }
 
         String base64Image = Base64.getEncoder().encodeToString(imageBytes);
-        String base64Metadata = Base64.getEncoder().encodeToString(metadata.getBytes(StandardCharsets.UTF_8));
+        String base64Metadata = Base64.getEncoder().encodeToString(
+            (metadata != null ? metadata : "").getBytes(StandardCharsets.UTF_8)
+        );
 
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("name", imageName);


### PR DESCRIPTION
## 📌연관된 이슈 번호
#92 

## ✨PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x]  기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝작업 내용
AR 해설을 위한 뷰포리아 API를 단계별로 분리하여 로직 수정했습니다.

1. 뷰포리아에 타겟 등록 후, 타겟 아이디와 작품 제목 DB에 저장 API
2. AI 서버와 연결해, 좌표값 및 해설 DB에 저장하는 API
3. 타겟 아이디로 AR 해설 조회 API

## 💬리뷰 포인트 (선택)

## 테스트 결과 (선택)
<img width="661" height="172" alt="image" src="https://github.com/user-attachments/assets/04e5c459-1fd5-4dfd-9ef7-f3d382e904a3" />

타겟 아이디와 작품 제목 저장

<img width="717" height="263" alt="image" src="https://github.com/user-attachments/assets/3e4c5b4a-836e-46b2-92b4-110efb4ff875" />

AI 서버에서 받아온 좌표값과 해설 저장

<img width="1411" height="535" alt="image" src="https://github.com/user-attachments/assets/1fcc4669-6a39-4e25-b5c6-0557bd97071f" />

타겟 아이디로 AR 해설 조회
